### PR TITLE
Fix `fetch` override string type check

### DIFF
--- a/src/ts/fetch-override.ts
+++ b/src/ts/fetch-override.ts
@@ -2,7 +2,7 @@
 const oldFetch = fetch;
 
 window.fetch = async function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-	if (input instanceof URL || input instanceof String) {
+	if (input instanceof URL || typeof input === 'string' || input instanceof String) {
 		return oldFetch(input, init);
 	}
 


### PR DESCRIPTION
Was breaking the Extension for Khan Academy in various places (e.g. https://github.com/ka-extension/ka-extension-ts/issues/271).

It's also just a bad idea to override native APIs in the first place.